### PR TITLE
Move various Types to the API from Engine.Core

### DIFF
--- a/src/testcentric.engine.api/Agents/AgentExitCodes.cs
+++ b/src/testcentric.engine.api/Agents/AgentExitCodes.cs
@@ -1,0 +1,19 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric.Engine.Agents
+{
+    public static class AgentExitCodes
+    {
+        public const int OK = 0;
+        public const int CANCELLED_BY_USER = 1;
+        public const int PARENT_PROCESS_TERMINATED = -1;
+        public const int FAILED_TO_START_REMOTE_AGENT = -2;
+        public const int DEBUGGER_SECURITY_VIOLATION = -3;
+        public const int DEBUGGER_NOT_IMPLEMENTED = -4;
+        public const int UNABLE_TO_LOCATE_AGENCY = -5;
+        public const int UNEXPECTED_EXCEPTION = -100;
+    }
+}

--- a/src/testcentric.engine.api/Communication/Messages/MessageCode.cs
+++ b/src/testcentric.engine.api/Communication/Messages/MessageCode.cs
@@ -1,0 +1,31 @@
+﻿// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestCentric.Engine.Communication.Messages
+{
+    public class MessageCode
+    {   // All length 4
+        public const string StartAgent = "STRT"; // not used
+        public const string StopAgent = "EXIT";
+        public const string CreateRunner = "RUNR";
+
+        public const string LoadCommand = "LOAD";
+        public const string ReloadCommand = "RELD";
+        public const string UnloadCommand = "UNLD";
+        public const string ExploreCommand = "XPLR";
+        public const string CountCasesCommand = "CNTC";
+        public const string RunCommand = "RSYN";
+        public const string RunAsyncCommand = "RASY";
+        public const string RequestStopCommand = "STOP";
+        public const string ForcedStopCommand = "ABRT";
+
+        public const string ProgressReport = "PROG";
+        public const string CommandResult = "RSLT";
+    }
+}

--- a/src/testcentric.engine.api/Communication/Messages/TestEngineMessage.cs
+++ b/src/testcentric.engine.api/Communication/Messages/TestEngineMessage.cs
@@ -1,0 +1,26 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+
+namespace TestCentric.Engine.Communication.Messages
+{
+    [Serializable]
+    public class TestEngineMessage
+    {
+        public TestEngineMessage(string code, string data)
+        {
+            Code = code;
+            Data = data;
+        }
+
+        public string Code { get; }
+        public string Data { get; }
+
+        // Alias properties for convenience
+        public string CommandName => Code;
+        public string Argument => Data;
+    }
+}

--- a/src/testcentric.engine.api/Communication/Protocols/ISerializationProtocol.cs
+++ b/src/testcentric.engine.api/Communication/Protocols/ISerializationProtocol.cs
@@ -1,0 +1,31 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using TestCentric.Engine.Communication.Messages;
+
+namespace TestCentric.Engine.Communication.Protocols
+{
+    public interface ISerializationProtocol
+    {
+        /// <summary>
+        /// Serializes a message to a byte array to send to remote application.
+        /// </summary>
+        /// <param name="message">Message to be serialized</param>
+        /// <returns>A byte[] containing the message, serialized as per the protocol.</returns>
+        byte[] Encode(TestEngineMessage message);
+
+        /// <summary>
+        /// Accept an array of bytes and deserialize the messages that are found.
+        /// A single call may provide no messages, part of a message, a single
+        /// message or multiple messages. Unused bytes are saved for use as
+        /// further calls are made.
+        /// </summary>
+        /// <param name="receivedBytes">The byte array to be deserialized</param>
+        /// <returns>An enumeration of TestEngineMessages</returns>
+        IEnumerable<TestEngineMessage> Decode(byte[] receivedBytes);
+    }
+}

--- a/src/testcentric.engine.api/EnginePackageSettings.cs
+++ b/src/testcentric.engine.api/EnginePackageSettings.cs
@@ -1,0 +1,213 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+namespace TestCentric
+{
+    /// <summary>
+    /// EngineSettings contains constant values that
+    /// are used as keys in setting up a TestPackage. 
+    /// Values here are used in the engine, and set by the runner.
+    /// Setting values may be a string, int or bool.
+    /// </summary>
+    public static class EnginePackageSettings
+    {
+        /// <summary>
+        /// Identify previously supported settings, which are no longer
+        /// supported, so that appropriate action may be taken.
+        /// </summary>
+        public static bool IsObsoleteSetting(string setting)
+            => setting == "ProcessModel" || setting == "DomainUsage";
+
+        #region Set by the Runner - Used by the Engine
+
+        /// <summary>
+        /// The name of the config to use in loading a project.
+        /// If not specified, the first config found is used.
+        /// </summary>
+        public const string ActiveConfig = "ActiveConfig";
+
+        /// <summary>
+        /// A list of the avaialble config names for this project.
+        /// </summary>
+        public const string ConfigNames = "ConfigNames";
+
+        /// <summary>
+        /// Bool indicating whether the engine should determine the private
+        /// bin path by examining the paths to all the tests. Defaults to
+        /// true unless PrivateBinPath is specified.
+        /// </summary>
+        public const string AutoBinPath = "AutoBinPath";
+
+        /// <summary>
+        /// The ApplicationBase to use in loading the tests. If not 
+        /// specified, and each assembly has its own process, then the
+        /// location of the assembly is used. For multiple  assemblies
+        /// in a single process, the closest common root directory is used.
+        /// </summary>
+        public const string BasePath = "BasePath";
+
+        /// <summary>
+        /// Path to the config file to use in running the tests. 
+        /// </summary>
+        public const string ConfigurationFile = "ConfigurationFile";
+
+        /// <summary>
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
+
+        /// <summary>
+        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// startup. Used only for debugging NUnit itself.
+        /// </summary>
+        public const string DebugAgent = "DebugAgent";
+
+        /// <summary>
+        /// Bool flag indicating that the DomainManager should throw a
+        /// <see cref="CannotUnloadAppDomainException" /> for testing purposes.
+        /// </summary>
+        public const string SimulateUnloadError = "DebugUnloadError";
+
+        /// <summary>
+        /// Bool flag indicating that the DomainManager should inject
+        /// an infinite loop for testing purposes.
+        /// </summary>
+        public const string SimulateUnloadTimeout = "DebugUnloadTimeout";
+
+        /// <summary>
+        /// The private binpath used to locate assemblies. Directory paths
+        /// is separated by a semicolon. It's an error to specify this and
+        /// also set AutoBinPath to true.
+        /// </summary>
+        public const string PrivateBinPath = "PrivateBinPath";
+
+        /// <summary>
+        /// The maximum number of test agents permitted to run simultaneously. 
+        /// </summary>
+        public const string MaxAgents = "MaxAgents";
+
+        /// <summary>
+        /// Indicates the desired runtime to use for the tests. Values 
+        /// are strings like "net-4.5", "mono-4.0", etc. Default is to
+        /// use the target framework for which an assembly was built.
+        /// </summary>
+        public const string RequestedRuntimeFramework = "RequestedRuntimeFramework";
+
+        /// <summary>
+        /// Indicates the Target runtime selected for use by the engine,
+        /// based on the requested runtime and assembly metadata.
+        /// </summary>
+        public const string TargetRuntimeFramework = "TargetRuntimeFramework";
+
+        /// <summary>
+        /// The name of the agent requested by the user, overriding
+        /// the default agent, which would otherwise be used.
+        /// </summary>
+        public const string RequestedAgentName = "RequestedAgentName";
+
+        /// <summary>
+        /// The name of the agent actually used for running tests.
+        /// </summary>
+        public const string SelectedAgentName = "SelectedAgentName";
+
+        /// <summary>
+        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
+        /// a 64-bit system. Ignored if set on a 32-bit system.
+        /// </summary>
+        public const string RunAsX86 = "RunAsX86";
+
+        /// <summary>
+        /// Indicates that test runners should be disposed after the tests are executed
+        /// </summary>
+        public const string DisposeRunners = "DisposeRunners";
+
+        /// <summary>
+        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Defaults to false.
+        /// </summary>
+        public const string ShadowCopyFiles = "ShadowCopyFiles";
+
+        /// <summary>
+        /// Bool flag indicating that user profile should be loaded on test runner processes
+        /// </summary>
+        public const string LoadUserProfile = "LoadUserProfile";
+
+        /// <summary>
+        /// Bool flag indicating that non-test assemblies should be skipped without error.
+        /// </summary>
+        public const string SkipNonTestAssemblies = "SkipNonTestAssemblies";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to pause execution of tests to allow
+        /// the user to attach a debugger.
+        /// </summary>
+        public const string PauseBeforeRun = "PauseBeforeRun";
+
+        /// <summary>
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
+        /// </summary>
+        public const string InternalTraceLevel = "InternalTraceLevel";
+
+        /// <summary>
+        /// The PrincipalPolicy to set on the test application domain. Values are:
+        /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
+        /// </summary>
+        public const string PrincipalPolicy = "PrincipalPolicy";
+
+        /// <summary>
+        /// Full path of the directory to be used for work and result files.
+        /// This path is provided to tests by the framework TestContext.
+        /// </summary>
+        public const string WorkDirectory = "WorkDirectory";
+
+        #endregion
+
+        #region Set and Used by the Engine - Visible to the Runner
+
+        /// <summary>
+        /// If the package represents an assembly, then this is the CLR version
+        /// stored in the assembly image. If it represents a project or other
+        /// group of assemblies, it is the maximum version for all the assemblies.
+        /// </summary>
+        public const string ImageRuntimeVersion = "ImageRuntimeVersion";
+
+        /// <summary>
+        /// True if any assembly in the package requires running as a 32-bit
+        /// process when on a 64-bit system.
+        /// </summary>
+        public const string ImageRequiresX86 = "ImageRequiresX86";
+
+        /// <summary>
+        /// True if any assembly in the package requires a special assembly resolution hook
+        /// in the default application domain in order to find dependent assemblies.
+        /// </summary>
+        public const string ImageRequiresDefaultAppDomainAssemblyResolver = "ImageRequiresDefaultAppDomainAssemblyResolver";
+
+        /// <summary>
+        /// The FrameworkName specified on a TargetFrameworkAttribute for the assembly
+        /// </summary>
+        public const string ImageTargetFrameworkName = "ImageTargetFrameworkName";
+
+        /// <summary>
+        /// The full name of the test framework referenced by the assembly
+        /// </summary>
+        public const string ImageTestFrameworkReference = "ImageTestFrameworkReference";
+
+        /// <summary>
+        /// The AssemblyQualifiedName of the framework driver to be used.
+        /// </summary>
+        public const string ImageFrameworkDriverReference = "ImageFrameworkDriverReference";
+
+        /// <summary>
+        /// True if the NUnit.Framework.NonTestAssemblyAttribute is present
+        /// </summary>
+        public const string ImageNonTestAssemblyAttribute = "ImageNonTestAssemblyAttribute";
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This is part of an effort to reduce the footprint of TestCentric.Engine.Core, possibly eliminating it in the future or possibly renaming it as a common utility assembly. 

In the current PR, the following Types are being added to the API

* EnginePackageSettings
* AgentExitCodes
* MessageCode
* TestEngineMessage
* ISerializationProtocol
